### PR TITLE
fix(nfs) use user defined ns in nfs server name

### DIFF
--- a/pygluu/kubernetes/templates/helm/charts/nfs/templates/pv.yaml
+++ b/pygluu/kubernetes/templates/helm/charts/nfs/templates/pv.yaml
@@ -11,5 +11,5 @@ spec:
   mountOptions:
     - nfsvers=4.1
   nfs:
-    server: nfs.default.svc.cluster.local # nfs is from svc {{ include "nfs.name" .}}
+    server: nfs.{{ .Values.global.namespace }}.svc.cluster.local  # nfs is from svc {{ include "nfs.name" .}}
     path: "/opt/shared-shibboleth-idp"


### PR DESCRIPTION
### What does this PR do?
Fix `nfs` PersistentVolume server URL to be more flexible in regards to namespace
Fix issue #50 

### How should this be manually tested
- Change namespace in root level `values.yaml` 
- Enable installation of `nfs` chart by setting `global.nfs.enabled` to true
- Run `helm template .` and look for nfs pv description
### Screenshots if possible
<img width="457" alt="Screenshot 2020-02-07 at 10 59 30" src="https://user-images.githubusercontent.com/13331207/74011485-015e4280-4999-11ea-9e3d-6a96f780f60f.png">
<img width="438" alt="Screenshot 2020-02-07 at 10 56 48" src="https://user-images.githubusercontent.com/13331207/74011492-091de700-4999-11ea-83a0-6a6bfa57bec7.png">
