### PR TITLE
Add Helm release name to "nfs" chart

### DIFF
--- a/pygluu/kubernetes/templates/helm/charts/nfs/templates/_helpers.tpl
+++ b/pygluu/kubernetes/templates/helm/charts/nfs/templates/_helpers.tpl
@@ -3,7 +3,11 @@
 Expand the name of the chart.
 */}}
 {{- define "nfs.name" -}}
+{{- if .Values.nameOverride -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -15,11 +19,11 @@ If release name contains chart name it will be used as a full name.
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
+{{- $fullname := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $fullname .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name $fullname | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/pygluu/kubernetes/templates/helm/charts/nfs/templates/pv.yaml
+++ b/pygluu/kubernetes/templates/helm/charts/nfs/templates/pv.yaml
@@ -11,5 +11,5 @@ spec:
   mountOptions:
     - nfsvers=4.1
   nfs:
-    server: nfs.{{ .Values.global.namespace }}.svc.cluster.local  # nfs is from svc {{ include "nfs.name" .}}
+    server: {{ include "nfs.name" . }}.{{ .Values.global.namespace }}.svc.cluster.local
     path: "/opt/shared-shibboleth-idp"

--- a/pygluu/kubernetes/templates/helm/charts/oxshibboleth/templates/statefulset.yaml
+++ b/pygluu/kubernetes/templates/helm/charts/oxshibboleth/templates/statefulset.yaml
@@ -97,5 +97,5 @@ spec:
           {{- else if and ( and .Values.global.cloud.enabled (eq .Values.global.provisioner "kubernetes.io/aws-ebs")) ( .Values.global.cloud.awsLocalStorage ) }}
           claimName: {{ .Release.Name }}-shared-shib-pvc
           {{- else }}
-          claimName: nfs
+          claimName: {{ include "nfs.name" . }}
           {{- end }} 

--- a/pygluu/kubernetes/templates/helm/charts/oxtrust/templates/statefulset.yml
+++ b/pygluu/kubernetes/templates/helm/charts/oxtrust/templates/statefulset.yml
@@ -98,7 +98,7 @@ spec:
             {{- else if and ( and .Values.global.cloud.enabled (eq .Values.global.provisioner "kubernetes.io/aws-ebs")) ( .Values.global.cloud.awsLocalStorage ) }}
             claimName: {{ .Release.Name }}-shared-shib-pvc
             {{- else }}
-            claimName: nfs
+            claimName: {{ include "nfs.name" . }}
             {{- end }}
       {{- if eq .Values.global.isDomainRegistered "false" }}
       hostAliases:


### PR DESCRIPTION
The currently deployed name "nfs" for PV, PVC, etc is too generic.
Adding the Helm release name to the chart.